### PR TITLE
Add hub installation

### DIFF
--- a/.github/actions/upload-release-asset/action.yml
+++ b/.github/actions/upload-release-asset/action.yml
@@ -9,6 +9,10 @@ runs:
   steps:
   - uses: actions/checkout@v3
 
+  - name: Install hub tool
+      run: |
+        sudo apt-get update && sudo apt-get install -y hub
+
   - name: Download Artifact
     uses: actions/download-artifact@v3
 


### PR DESCRIPTION
There was an issue due to `ubuntu-latest` updates. #2

The root cause was `hub` package excluded from `ubuntu-latest`, so I added `run` which install the `hub`.